### PR TITLE
[2단계 - 로또 리팩토링] 제프(변우영) 미션 제출합니다.

### DIFF
--- a/src/main/java/lotto/controller/LottoController.java
+++ b/src/main/java/lotto/controller/LottoController.java
@@ -21,7 +21,7 @@ public class LottoController {
         OutputView.printProfitRate(winningResult.calculateProfitRate(purchaseAmount));
     }
 
-    public LottoTicket issueTicket(PurchaseAmount purchaseAmount) {
+    public LottoTicket issueTicket(final PurchaseAmount purchaseAmount) {
         List<Lotto> lottos = new ArrayList<>();
         for (int i = 0; i < purchaseAmount.countNumberOfPurchases(); i++) {
             List<Integer> lottoNumbers = LottoNumberGenerator.generate();
@@ -31,7 +31,7 @@ public class LottoController {
         return new LottoTicket(lottos);
     }
 
-    private List<MatchResultDto> getMatchResultDtos(LottoTicket lottoTicket) {
+    private List<MatchResultDto> getMatchResultDtos(final LottoTicket lottoTicket) {
         WinningNumber winningNumber = new WinningNumber(InputView.inputWinningNumbers());
         BonusNumber bonusNumber = new BonusNumber(InputView.inputBonusNumber());
         return lottoTicket.deriveMatchResults(winningNumber, bonusNumber);

--- a/src/main/java/lotto/domain/BonusNumber.java
+++ b/src/main/java/lotto/domain/BonusNumber.java
@@ -13,11 +13,11 @@ public class BonusNumber {
         this.bonusNumber = bonusNumber;
     }
 
-    public boolean isMatch(List<Integer> numbers) {
+    public boolean isMatch(final List<Integer> numbers) {
         return numbers.contains(bonusNumber);
     }
 
-    private void validateRange(int bonusNumber) {
+    private void validateRange(final int bonusNumber) {
         if (bonusNumber < LottoConstants.MIN_NUMBER || bonusNumber > LottoConstants.MAX_NUMBER) {
             throw new IllegalArgumentException("보너스 번호는 " + LottoConstants.MIN_NUMBER + "~" +
                     LottoConstants.MAX_NUMBER + " 사이의 수를 입력해야 합니다.");

--- a/src/main/java/lotto/domain/Lotto.java
+++ b/src/main/java/lotto/domain/Lotto.java
@@ -7,7 +7,7 @@ public class Lotto {
     private final List<Integer> numbers;
 
     public Lotto(List<Integer> numbers) {
-        this.numbers = numbers;
+        this.numbers = List.copyOf(numbers);
     }
 
     public MatchResultDto deriveMatchResult(WinningNumber winningNumber, BonusNumber bonusNumber) {

--- a/src/main/java/lotto/domain/Lotto.java
+++ b/src/main/java/lotto/domain/Lotto.java
@@ -10,15 +10,16 @@ public class Lotto {
         this.numbers = List.copyOf(numbers);
     }
 
-    public MatchResultDto deriveMatchResult(WinningNumber winningNumber, BonusNumber bonusNumber) {
+    public MatchResultDto deriveMatchResult(final WinningNumber winningNumber,
+                                            final BonusNumber bonusNumber) {
         return new MatchResultDto(countWinningNumber(winningNumber), containBonusNumber(bonusNumber));
     }
 
-    public boolean containBonusNumber(BonusNumber bonusNumber) {
+    public boolean containBonusNumber(final BonusNumber bonusNumber) {
         return bonusNumber.isMatch(numbers);
     }
 
-    public int countWinningNumber(WinningNumber winningNumber) {
+    public int countWinningNumber(final WinningNumber winningNumber) {
         return winningNumber.countMatchingNumber(numbers);
     }
 }

--- a/src/main/java/lotto/domain/LottoNumberGenerator.java
+++ b/src/main/java/lotto/domain/LottoNumberGenerator.java
@@ -8,6 +8,10 @@ import java.util.List;
 
 public class LottoNumberGenerator {
 
+    private LottoNumberGenerator() {
+
+    }
+
     public static List<Integer> generate() {
         List<Integer> lottoNumbers = new ArrayList<>();
         for (int i = LottoConstants.MIN_NUMBER; i <= LottoConstants.MAX_NUMBER; i++) {

--- a/src/main/java/lotto/domain/LottoNumberGenerator.java
+++ b/src/main/java/lotto/domain/LottoNumberGenerator.java
@@ -22,7 +22,7 @@ public class LottoNumberGenerator {
         return issue(lottoNumbers);
     }
 
-    private static List<Integer> issue(List<Integer> lottoNumbers) {
+    private static List<Integer> issue(final List<Integer> lottoNumbers) {
         List<Integer> generatedNumber = new ArrayList<>();
         for (int i = 0; i < LottoConstants.NUMBER_COUNT; i++) {
             generatedNumber.add(lottoNumbers.get(i));

--- a/src/main/java/lotto/domain/LottoRank.java
+++ b/src/main/java/lotto/domain/LottoRank.java
@@ -33,9 +33,6 @@ public enum LottoRank {
     }
 
     public static LottoRank findRankWithMatchResult(final MatchResultDto matchResultDto) {
-        if (matchResultDto.getMatchCount() == SECOND_PLACE.matchCount && matchResultDto.isContainsBonusNumber()) {
-            return SECOND_PLACE;
-        }
 
         return Arrays.stream(values())
                 .filter(rank -> rank.matchCount == matchResultDto.getMatchCount())

--- a/src/main/java/lotto/domain/LottoRank.java
+++ b/src/main/java/lotto/domain/LottoRank.java
@@ -32,7 +32,7 @@ public enum LottoRank {
         return winningAmount;
     }
 
-    public static LottoRank findRankWithMatchResult(MatchResultDto matchResultDto) {
+    public static LottoRank findRankWithMatchResult(final MatchResultDto matchResultDto) {
         if (matchResultDto.getMatchCount() == SECOND_PLACE.matchCount && matchResultDto.isContainsBonusNumber()) {
             return SECOND_PLACE;
         }
@@ -61,7 +61,7 @@ public enum LottoRank {
         return String.format("%d개 일치 (%d원)", getMatchCount(), getWinningAmount());
     }
 
-    public long calculateWinningAmount(int count) {
+    public long calculateWinningAmount(final int count) {
         return winningAmount * count;
     }
 }

--- a/src/main/java/lotto/domain/LottoRank.java
+++ b/src/main/java/lotto/domain/LottoRank.java
@@ -7,12 +7,12 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 public enum LottoRank {
-    NO_REWARD(0, 0L, false),
-    FIFTH_PLACE(3, 5_000L, false),
-    FORTH_PLACE(4, 50_000L, false),
-    THIRD_PLACE(5, 1_500_000L, false),
-    SECOND_PLACE(5, 30_000_000L, true),
-    FIRST_PLACE(6, 2_000_000_000L, false);
+    NONE(0, 0L, false),
+    FIFTH(3, 5_000L, false),
+    FORTH(4, 50_000L, false),
+    THIRD(5, 1_500_000L, false),
+    SECOND(5, 30_000_000L, true),
+    FIRST(6, 2_000_000_000L, false);
 
     private final int matchCount;
     private final long winningAmount;
@@ -38,12 +38,12 @@ public enum LottoRank {
                 .filter(rank -> rank.matchCount == matchResultDto.getMatchCount())
                 .filter(rank -> rank.containsBonus == matchResultDto.isContainsBonusNumber())
                 .findAny()
-                .orElse(NO_REWARD);
+                .orElse(NONE);
     }
 
     public static Map<LottoRank, String> getRankInfo() {
         return Arrays.stream(values())
-                .filter(lottoRank -> lottoRank != NO_REWARD)
+                .filter(lottoRank -> lottoRank != NONE)
                 .collect(Collectors.toMap(Function.identity(), LottoRank::generateRankMessage,
                         (oldValue, newValue) -> oldValue,
                         LinkedHashMap::new
@@ -51,7 +51,7 @@ public enum LottoRank {
     }
 
     private String generateRankMessage() {
-        if (this == LottoRank.SECOND_PLACE) {
+        if (this == LottoRank.SECOND) {
             return String.format("%d개 일치, 보너스 볼 일치(%d원)", getMatchCount(), getWinningAmount());
         }
 

--- a/src/main/java/lotto/domain/LottoRank.java
+++ b/src/main/java/lotto/domain/LottoRank.java
@@ -1,7 +1,7 @@
 package lotto.domain;
 
 import java.util.Arrays;
-import java.util.LinkedHashMap;
+import java.util.EnumMap;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -44,9 +44,11 @@ public enum LottoRank {
     public static Map<LottoRank, String> getRankInfo() {
         return Arrays.stream(values())
                 .filter(lottoRank -> lottoRank != NONE)
-                .collect(Collectors.toMap(Function.identity(), LottoRank::generateRankMessage,
+                .collect(Collectors.toMap(
+                        Function.identity(),
+                        LottoRank::generateRankMessage,
                         (oldValue, newValue) -> oldValue,
-                        LinkedHashMap::new
+                        () -> new EnumMap<>(LottoRank.class)
                 ));
     }
 

--- a/src/main/java/lotto/domain/LottoTicket.java
+++ b/src/main/java/lotto/domain/LottoTicket.java
@@ -1,6 +1,5 @@
 package lotto.domain;
 
-import java.util.ArrayList;
 import java.util.List;
 
 public class LottoTicket {
@@ -13,11 +12,8 @@ public class LottoTicket {
 
     public List<MatchResultDto> deriveMatchResults(final WinningNumber winningNumber,
                                                    final BonusNumber bonusNumber) {
-        List<MatchResultDto> results = new ArrayList<>();
-        for (Lotto lotto : lottos) {
-            results.add(lotto.deriveMatchResult(winningNumber, bonusNumber));
-        }
-        return results;
-
+        return lottos.stream()
+                .map(lotto -> lotto.deriveMatchResult(winningNumber, bonusNumber))
+                .toList();
     }
 }

--- a/src/main/java/lotto/domain/LottoTicket.java
+++ b/src/main/java/lotto/domain/LottoTicket.java
@@ -11,7 +11,8 @@ public class LottoTicket {
         this.lottos = lottos;
     }
 
-    public List<MatchResultDto> deriveMatchResults(WinningNumber winningNumber, BonusNumber bonusNumber) {
+    public List<MatchResultDto> deriveMatchResults(final WinningNumber winningNumber,
+                                                   final BonusNumber bonusNumber) {
         List<MatchResultDto> results = new ArrayList<>();
         for (Lotto lotto : lottos) {
             results.add(lotto.deriveMatchResult(winningNumber, bonusNumber));

--- a/src/main/java/lotto/domain/MatchResults.java
+++ b/src/main/java/lotto/domain/MatchResults.java
@@ -1,6 +1,6 @@
 package lotto.domain;
 
-import java.util.HashMap;
+import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
 
@@ -13,7 +13,7 @@ public class MatchResults {
     }
 
     public Map<LottoRank, Integer> getWinningResult() {
-        Map<LottoRank, Integer> winningInfo = new HashMap<>();
+        Map<LottoRank, Integer> winningInfo = new EnumMap<>(LottoRank.class);
 
         for (MatchResultDto matchResult : matchResults) {
             LottoRank lottoRank = LottoRank.findRankWithMatchResult(matchResult);

--- a/src/main/java/lotto/domain/PurchaseAmount.java
+++ b/src/main/java/lotto/domain/PurchaseAmount.java
@@ -20,13 +20,13 @@ public class PurchaseAmount {
         return (int) amount / LottoConstants.LOTTO_PRICE;
     }
 
-    private void validateAmount(long purchaseAmount) {
+    private void validateAmount(final long purchaseAmount) {
         if (purchaseAmount % LottoConstants.LOTTO_PRICE != 0) {
             throw new IllegalArgumentException("구매 금액은 " + LottoConstants.LOTTO_PRICE + "원 단위어야 합니다.");
         }
     }
 
-    private void validatePositive(long purchaseAmount) {
+    private void validatePositive(final long purchaseAmount) {
         if (purchaseAmount <= 0) {
             throw new IllegalArgumentException("구매 금액은 양수여야 합니다.");
         }

--- a/src/main/java/lotto/domain/PurchaseAmount.java
+++ b/src/main/java/lotto/domain/PurchaseAmount.java
@@ -7,6 +7,7 @@ public class PurchaseAmount {
     private final long amount;
 
     public PurchaseAmount(long purchaseAmount) {
+        validatePositive(purchaseAmount);
         validateAmount(purchaseAmount);
         this.amount = purchaseAmount;
     }
@@ -22,6 +23,12 @@ public class PurchaseAmount {
     private void validateAmount(long purchaseAmount) {
         if (purchaseAmount % LottoConstants.LOTTO_PRICE != 0) {
             throw new IllegalArgumentException("구매 금액은 " + LottoConstants.LOTTO_PRICE + "원 단위어야 합니다.");
+        }
+    }
+
+    private void validatePositive(long purchaseAmount) {
+        if (purchaseAmount <= 0) {
+            throw new IllegalArgumentException("구매 금액은 양수여야 합니다.");
         }
     }
 }

--- a/src/main/java/lotto/domain/WinningNumber.java
+++ b/src/main/java/lotto/domain/WinningNumber.java
@@ -14,7 +14,7 @@ public class WinningNumber {
         validateSize(numbers);
         validateDuplicate(numbers);
         validateRange(numbers);
-        this.winningNumbers = numbers;
+        this.winningNumbers = List.copyOf(numbers);
     }
 
     public int countMatchingNumber(List<Integer> numbers) {

--- a/src/main/java/lotto/domain/WinningNumber.java
+++ b/src/main/java/lotto/domain/WinningNumber.java
@@ -17,26 +17,26 @@ public class WinningNumber {
         this.winningNumbers = List.copyOf(numbers);
     }
 
-    public int countMatchingNumber(List<Integer> numbers) {
+    public int countMatchingNumber(final List<Integer> numbers) {
         return (int) numbers.stream()
                 .filter(winningNumbers::contains)
                 .count();
     }
 
-    private void validateSize(List<Integer> numbers) {
+    private void validateSize(final List<Integer> numbers) {
         if (numbers.size() != LottoConstants.NUMBER_COUNT) {
             throw new IllegalArgumentException("당첨 번호는 " + LottoConstants.NUMBER_COUNT + "개여야 합니다.");
         }
     }
 
-    private void validateDuplicate(List<Integer> numbers) {
+    private void validateDuplicate(final List<Integer> numbers) {
         Set<Integer> set = new HashSet<>(numbers);
         if (set.size() != LottoConstants.NUMBER_COUNT) {
             throw new IllegalArgumentException("당첨 번호는 중복될 수 없습니다.");
         }
     }
 
-    private void validateRange(List<Integer> numbers) {
+    private void validateRange(final List<Integer> numbers) {
         if (numbers.stream()
                 .anyMatch(number -> number < LottoConstants.MIN_NUMBER || number > LottoConstants.MAX_NUMBER)) {
             throw new IllegalArgumentException("당첨 번호는 " + LottoConstants.MIN_NUMBER

--- a/src/main/java/lotto/domain/WinningResult.java
+++ b/src/main/java/lotto/domain/WinningResult.java
@@ -16,11 +16,9 @@ public class WinningResult {
     }
 
     private long sumTotalProfit(Map<LottoRank, Integer> winningInfo) {
-        long sum = 0;
-        for (LottoRank lottoRank : winningInfo.keySet()) {
-            sum += lottoRank.calculateWinningAmount(winningInfo.get(lottoRank));
-        }
-
-        return sum;
+        return winningInfo.entrySet().stream()
+                .mapToLong(entry
+                        -> entry.getKey().calculateWinningAmount(entry.getValue()))
+                .sum();
     }
 }

--- a/src/main/java/lotto/domain/WinningResult.java
+++ b/src/main/java/lotto/domain/WinningResult.java
@@ -10,15 +10,15 @@ public class WinningResult {
         this.winningInfo = winningInfo;
     }
 
-    public double calculateProfitRate(PurchaseAmount purchaseAmount) {
+    public double calculateProfitRate(final PurchaseAmount purchaseAmount) {
         long totalProfit = sumTotalProfit(winningInfo);
         return (double) totalProfit / purchaseAmount.getAmount();
     }
 
-    private long sumTotalProfit(Map<LottoRank, Integer> winningInfo) {
+    private long sumTotalProfit(final Map<LottoRank, Integer> winningInfo) {
         return winningInfo.entrySet().stream()
-                .mapToLong(entry
-                        -> entry.getKey().calculateWinningAmount(entry.getValue()))
+                .mapToLong(entry ->
+                        entry.getKey().calculateWinningAmount(entry.getValue()))
                 .sum();
     }
 }

--- a/src/main/java/lotto/util/Converter.java
+++ b/src/main/java/lotto/util/Converter.java
@@ -9,7 +9,7 @@ public class Converter {
 
     }
 
-    public static int convertToInteger(String input) {
+    public static int convertToInteger(final String input) {
         try {
             return Integer.parseInt(input);
         } catch (NumberFormatException e) {
@@ -17,7 +17,7 @@ public class Converter {
         }
     }
 
-    public static List<Integer> convertToIntegerList(String input) {
+    public static List<Integer> convertToIntegerList(final String input) {
         try {
             return Arrays.stream(input.split(","))
                     .map(s -> Integer.parseInt(s.trim()))

--- a/src/main/java/lotto/view/OutputView.java
+++ b/src/main/java/lotto/view/OutputView.java
@@ -19,12 +19,12 @@ public class OutputView {
         System.out.println(count + "개를 구매했습니다.");
     }
 
-    public static void printLottos(List<Integer> lottoNumbers) {
+    public static void printLottos(final List<Integer> lottoNumbers) {
         List<Integer> sortedNumbers = lottoNumbers.stream().sorted().toList();
         System.out.println(sortedNumbers);
     }
 
-    public static void printWinningStatics(Map<LottoRank, Integer> winningInfo) {
+    public static void printWinningStatics(final Map<LottoRank, Integer> winningInfo) {
         System.out.println("\n당첨 통계");
         System.out.println("---------");
         Map<LottoRank, String> rankInfo = LottoRank.getRankInfo();
@@ -34,7 +34,7 @@ public class OutputView {
         }
     }
 
-    public static void printProfitRate(double profitRate) {
+    public static void printProfitRate(final double profitRate) {
         if (profitRate >= PROFIT_STANDARD) {
             System.out.printf("총 수익률은 %.2f입니다.(기준이 1이기 때문에 결과적으로 %s이라는 의미임)", profitRate, PROFIT);
             return;

--- a/src/test/java/lotto/domain/BonusNumberTest.java
+++ b/src/test/java/lotto/domain/BonusNumberTest.java
@@ -7,9 +7,17 @@ import org.junit.jupiter.api.Test;
 class BonusNumberTest {
 
     @Test
-    @DisplayName("보너스번호의 범위 외 숫자가 입력되면 예외를 발생시킨다.")
-    void validateRange() {
+    @DisplayName("보너스번호의 상한값보다 큰 숫자가 입력되면 예외를 발생시킨다.")
+    void validateRangeWithNumberAboveMaxThrowsException() {
         Assertions.assertThatThrownBy(() -> new BonusNumber(46))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("보너스 번호는 1~45 사이의 수를 입력해야 합니다.");
+    }
+
+    @Test
+    @DisplayName("보너스번호의 하한값보다 작은 숫자가 입력되면 예외를 발생시킨다.")
+    void validateRangeWithNumberBelowMinThrowsException() {
+        Assertions.assertThatThrownBy(() -> new BonusNumber(-1))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("보너스 번호는 1~45 사이의 수를 입력해야 합니다.");
     }

--- a/src/test/java/lotto/domain/LottoRankTest.java
+++ b/src/test/java/lotto/domain/LottoRankTest.java
@@ -76,7 +76,7 @@ class LottoRankTest {
     void getRankInfo() {
         Map<LottoRank, String> rankInfo = LottoRank.getRankInfo();
 
-        assertFalse(rankInfo.containsKey(LottoRank.NO_REWARD));
+        assertFalse(rankInfo.containsKey(LottoRank.NONE));
     }
 
     @Test
@@ -84,7 +84,7 @@ class LottoRankTest {
     void getRankMessage() {
         Map<LottoRank, String> rankInfo = LottoRank.getRankInfo();
 
-        assertEquals("6개 일치 (2000000000원)", rankInfo.get(LottoRank.FIRST_PLACE));
-        assertEquals("5개 일치, 보너스 볼 일치(30000000원)", rankInfo.get(LottoRank.SECOND_PLACE));
+        assertEquals("6개 일치 (2000000000원)", rankInfo.get(LottoRank.FIRST));
+        assertEquals("5개 일치, 보너스 볼 일치(30000000원)", rankInfo.get(LottoRank.SECOND));
     }
 }

--- a/src/test/java/lotto/domain/LottoRankTest.java
+++ b/src/test/java/lotto/domain/LottoRankTest.java
@@ -33,12 +33,32 @@ class LottoRankTest {
 
     @Test
     @DisplayName("로또 3등 당첨 테스트")
-    void findRank_First_Place() {
+    void findThirdRank() {
         MatchResultDto matchResultDto = new MatchResultDto(5, false);
 
         LottoRank lottoRank = LottoRank.findRankWithMatchResult(matchResultDto);
 
         assertThat(lottoRank.getWinningAmount()).isEqualTo(1_500_000L);
+    }
+
+    @Test
+    @DisplayName("로또 4등 당첨 테스트")
+    void findForthRank() {
+        MatchResultDto matchResultDto = new MatchResultDto(4, false);
+
+        LottoRank lottoRank = LottoRank.findRankWithMatchResult(matchResultDto);
+
+        assertThat(lottoRank.getWinningAmount()).isEqualTo(50_000L);
+    }
+
+    @Test
+    @DisplayName("로또 5등 당첨 테스트")
+    void findFifthRank() {
+        MatchResultDto matchResultDto = new MatchResultDto(3, false);
+
+        LottoRank lottoRank = LottoRank.findRankWithMatchResult(matchResultDto);
+
+        assertThat(lottoRank.getWinningAmount()).isEqualTo(5_000L);
     }
 
     @Test

--- a/src/test/java/lotto/domain/LottoRankTest.java
+++ b/src/test/java/lotto/domain/LottoRankTest.java
@@ -6,8 +6,6 @@ import org.junit.jupiter.api.Test;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 
 class LottoRankTest {
 
@@ -76,7 +74,7 @@ class LottoRankTest {
     void getRankInfo() {
         Map<LottoRank, String> rankInfo = LottoRank.getRankInfo();
 
-        assertFalse(rankInfo.containsKey(LottoRank.NONE));
+        assertThat(rankInfo.containsKey(LottoRank.NONE)).isFalse();
     }
 
     @Test
@@ -84,7 +82,7 @@ class LottoRankTest {
     void getRankMessage() {
         Map<LottoRank, String> rankInfo = LottoRank.getRankInfo();
 
-        assertEquals("6개 일치 (2000000000원)", rankInfo.get(LottoRank.FIRST));
-        assertEquals("5개 일치, 보너스 볼 일치(30000000원)", rankInfo.get(LottoRank.SECOND));
+        assertThat(rankInfo.get(LottoRank.FIRST)).isEqualTo("6개 일치 (2000000000원)");
+        assertThat(rankInfo.get(LottoRank.SECOND)).isEqualTo("5개 일치, 보너스 볼 일치(30000000원)");
     }
 }

--- a/src/test/java/lotto/domain/MatchResultsTest.java
+++ b/src/test/java/lotto/domain/MatchResultsTest.java
@@ -24,10 +24,10 @@ class MatchResultsTest {
 
         Map<LottoRank, Integer> winningResult = matchResults.getWinningResult();
 
-        Assertions.assertThat(winningResult.get(LottoRank.FIRST_PLACE)).isEqualTo(1);
-        Assertions.assertThat(winningResult.get(LottoRank.SECOND_PLACE)).isEqualTo(1);
-        Assertions.assertThat(winningResult.get(LottoRank.THIRD_PLACE)).isEqualTo(2);
-        Assertions.assertThat(winningResult.get(LottoRank.FIFTH_PLACE)).isEqualTo(1);
-        Assertions.assertThat(winningResult.get(LottoRank.NO_REWARD)).isEqualTo(1);
+        Assertions.assertThat(winningResult.get(LottoRank.FIRST)).isEqualTo(1);
+        Assertions.assertThat(winningResult.get(LottoRank.SECOND)).isEqualTo(1);
+        Assertions.assertThat(winningResult.get(LottoRank.THIRD)).isEqualTo(2);
+        Assertions.assertThat(winningResult.get(LottoRank.FIFTH)).isEqualTo(1);
+        Assertions.assertThat(winningResult.get(LottoRank.NONE)).isEqualTo(1);
     }
 }

--- a/src/test/java/lotto/domain/PurchaseAmountTest.java
+++ b/src/test/java/lotto/domain/PurchaseAmountTest.java
@@ -1,10 +1,10 @@
 package lotto.domain;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class PurchaseAmountTest {
 
@@ -21,12 +21,9 @@ class PurchaseAmountTest {
 
     @Test
     @DisplayName("구매 금액이 1000원 단위가 아닌 경우, 예외를 발생시킨다.")
-    void validateCollectAmount() {
-
-        IllegalArgumentException exception = Assertions.assertThrows(IllegalArgumentException.class, () -> {
-            purchaseAmount = new PurchaseAmount(25670);
-        });
-
-        assertThat(exception.getMessage()).isEqualTo("구매 금액은 1000원 단위어야 합니다.");
+    void validateUnitOfThousandWon() {
+        assertThatThrownBy(() -> new PurchaseAmount(25670))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("구매 금액은 1000원 단위어야 합니다.");
     }
 }

--- a/src/test/java/lotto/domain/PurchaseAmountTest.java
+++ b/src/test/java/lotto/domain/PurchaseAmountTest.java
@@ -26,4 +26,20 @@ class PurchaseAmountTest {
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("구매 금액은 1000원 단위어야 합니다.");
     }
+
+    @Test
+    @DisplayName("구매 금액이 0인 경우, 예외를 발생시킨다.")
+    void throwsExceptionWhenAmountIsZero() {
+        assertThatThrownBy(() -> new PurchaseAmount(0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("구매 금액은 양수여야 합니다.");
+    }
+
+    @Test
+    @DisplayName("구매 금액이 음수인 경우, 예외를 발생시킨다.")
+    void throwsExceptionWhenAmountIsNegative() {
+        assertThatThrownBy(() -> new PurchaseAmount(-1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("구매 금액은 양수여야 합니다.");
+    }
 }

--- a/src/test/java/lotto/domain/WinningResultTest.java
+++ b/src/test/java/lotto/domain/WinningResultTest.java
@@ -9,7 +9,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 class WinningResultTest {
 
-    private final WinningResult winningResult = new WinningResult(Map.of(LottoRank.FIFTH_PLACE, 3));
+    private final WinningResult winningResult = new WinningResult(Map.of(LottoRank.FIFTH, 3));
     private PurchaseAmount purchaseAmount;
 
     @Test


### PR DESCRIPTION
안녕하세요 베루스
말씀해주신 로또 4,5등에 대한 테스트를 추가했고 개인적으로 리팩토링할 부분을 고민해봤습니다. 
프롤로그 내용도 수정해봤어요! https://prolog.techcourse.co.kr/studylogs/3876

### 음수 입력 시, 예외 사항이 터지도록 수정했습니다.
구매금액을 입력 받을 때, 음수가 들어가면 예외 메시지가 발생하도록 수정했습니다.

### 생성자 내부에 방어적 복사를 도입했습니다.
객체 생성 시점에 컬렉션 원본과의 주소 공유를 끊어내기 위해 방어적 복사를 사용했습니다. new 를 사용해 새로운 컬렉션으로 복사하는 방식과 List.copyOf를 사용하는 방식, Collections.unmodifiableList()를 사용하는 방식을 두고 고민해봤습니다. Integer는 불변객체이기 때문에 해당 리스트를 인자로 받아와서 깊은 복사까지 할 필요는 없다고 생각해서 List.copyOf를 사용했습니다. new ArrayList<>()를 사용해 복사하면 리스트가 가변이기 때문에 내부에서 조작할 위험이 있다고 판단했습니다. 제가 이해한게 맞을까요?
그리고 Collections.unmodifiableList()와 new ArrayList<>()를 함께 사용해서 깊은 복사를 진행하는 경우는 특정 객체로 이루어진 리스트를 받아왔을 때만 해당되는지 궁금합니다!

###  entrySet()을 사용해 맵 조회 비용을 줄였습니다.
keySet을 이용하는 대신 entrySet()을 사용했고 stream을 도입했습니다. 스트림을 사용한 경우와 다음 코드 중에 어떤 방식이 더 좋은 코드일까요? 유지보수 면에선 for문을 사용하는 것이 좋을 것 같은데, stream을 사용하면 가독성 면에서 장점이 있는 것 같습니다.
    
    
        private long sumTotalProfit(Map<LottoRank, Integer> winningInfo) {
            long sum = 0;
            for (Map.Entry<LottoRank, Integer> entry : winningInfo.entrySet()) {
                sum += entry.getKey().calculateWinningAmount(entry.getValue());
            }
    
            return sum;
        }
    
    

### 메서드 파라미터에 final 키워드를 추가했습니다.
메서드 내에서 파라미터로 받아온 인자의 재할당을 막아 데이터의 정합성을 유지하기 위해 사용했습니다. 또한, 제3자가 제 코드를 봤을 때 메서드 로직에 따라 값이 변경되지 않을 것이라는 걸 쉽게 파악할 수 있다는 장점이 있을 것 같습니다.
인자에 final을 사용하는 방식을 이번 우테코 강의를 들으며 처음 알게 되었는데 실무에서도 파라미터에 final을 써주는 경우가 많은지 궁금합니다!

### EnumMap을 도입했습니다.
key가 enum인 HashMap을 EnumMap으로 변경했습니다. HashMap과 다르게 해싱 과정이 없어 해시 충돌 가능성이 없고, 인덱스 기반으로 값을 조회하기 때문에 성능 개선이 될 것이라 판단했습니다.